### PR TITLE
added filesize to identification

### DIFF
--- a/acacore/models/identification.py
+++ b/acacore/models/identification.py
@@ -11,6 +11,7 @@ class Identification(ACABase):
     puid: Optional[str]
     signature: Optional[str]
     warning: Optional[str]
+    file_size: Optional[int]
 
     # noinspection PyNestedDecorators
     @model_validator(mode="before")


### PR DESCRIPTION
This is done such that `digiarch` can use the file-size supplied by `sf`, instead of calculating it on its own (i have counted, it calculates it at least 3 times for each file!)