### PR TITLE
added the file extension to the ExtractAction model, since this data i used by renamer and it is for most files also data that we ahve in the fileformats.yml

### DIFF
--- a/acacore/models/reference_files.py
+++ b/acacore/models/reference_files.py
@@ -39,12 +39,12 @@ class ExtractAction(BaseModel):
 
     Attributes:
         tool (str): The name of the tool used for extraction.
-        file_extension (Optional[str]): The suffix that the file should have. Defaults to None.
+        extension (Optional[str]): The suffix that the file should have. Defaults to None.
         dir_suffix (str): The output directory where the extracted data will be saved.
     """
 
     tool: str
-    file_extension: Optional[str] = None
+    extension: Optional[str] = None
     dir_suffix: str
 
 

--- a/acacore/models/reference_files.py
+++ b/acacore/models/reference_files.py
@@ -39,10 +39,12 @@ class ExtractAction(BaseModel):
 
     Attributes:
         tool (str): The name of the tool used for extraction.
+        file_extension (Optional[str]): The suffix that the file should have. Defaults to None.
         dir_suffix (str): The output directory where the extracted data will be saved.
     """
 
     tool: str
+    file_extension: Optional[str] = None
     dir_suffix: str
 
 


### PR DESCRIPTION
This is some functionality that Unarchiver requires.

Some of the tools we use to unpack certain fileformats are very strict as to what file extensions the files that they work with can have, so we need to update the filles which have the wrong extensions